### PR TITLE
Fixed linux build

### DIFF
--- a/cpp-constants.mk
+++ b/cpp-constants.mk
@@ -1,8 +1,8 @@
 # Shared constants that facilitate the building of multiple C++ projects
 
 # g++ flags
-GPP_FLAGS_DEBUG = -std=c++11 -O0 -g3
-GPP_FLAGS_SHIP = -std=c++11 -O3
+GPP_FLAGS_DEBUG = -pthread -std=c++11 -O0 -g3
+GPP_FLAGS_SHIP = -pthread -std=c++11 -O3
 # emcc flags
 EMCC_FLAGS_DEBUG = -std=c++11 -O0 -g4 -s NO_EXIT_RUNTIME=1 -s EXCEPTION_DEBUG=1 -s SAFE_HEAP=1
 EMCC_FLAGS_SHIP = -std=c++11 -Oz -s NO_EXIT_RUNTIME=1


### PR DESCRIPTION
Linux currently fires the following message due to the use of pthreads
```
undefined reference to `pthread_create'
```

Overall we need to include pthread as a build flag. Tested on windows, not OSX. We shouldn't add a release tag until we test this on OSX.